### PR TITLE
Mark the project as no longer maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **This project is no longer maintained.** Please use an alternative such as [grunt-browserify](https://github.com/jmreidy/grunt-browserify).
+
 # grunt-coffeeify
 
 > A grunt plugin for browserifying your coffee + js projects!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-coffeeify",
-  "description": "A grunt plugin for browserifying your coffee + js projects!",
+  "description": "DEPRECATED A grunt plugin for browserifying your coffee + js projects!",
   "version": "0.1.3",
   "homepage": "https://github.com/Banno/grunt-coffeeify",
   "author": {


### PR DESCRIPTION
This project is still used (and works) with [Banno CMS](https://github.com/Banno/banno-cms). But development has moved away from those and there are better alternatives, so we should make a note of that in a public project like this. This PR adds a deprecation notice to the README and the npm manifest.

closes #10 
closes #11
closes #13
closes #14
closes #16
closes #17
